### PR TITLE
chore: clean up empty feature folders and shared policy

### DIFF
--- a/src/app/features/README.md
+++ b/src/app/features/README.md
@@ -1,0 +1,16 @@
+# Features Folder Notes
+
+This project keeps feature code under role-based modules that are already implemented.
+
+## Removed placeholder folders
+
+The following empty folders are intentionally removed because the functionality already exists in other modules:
+
+- `src/app/features/booking/` -> use `src/app/features/camper/bookings/` and `src/app/features/camper/booking-checkout/`
+- `src/app/features/dashboard/` -> use role dashboards under `src/app/features/merchant/merchant-dashboard/` and `src/app/features/admin/admin-dashboard/`
+- `src/app/features/inventory/` -> use merchant inventory/product flows under `src/app/features/merchant/campsites/`
+
+## `shared/` folder policy
+
+`src/app/shared/` is intentionally not present until reusable cross-feature modules are introduced.
+Reusable shared models/components are planned to be implemented in Issue #4.


### PR DESCRIPTION
## Summary
- remove empty placeholder folders from local workspace: features/booking, features/dashboard, features/inventory, and shared
- add feature-structure note in src/app/features/README.md to document intended module locations
- document shared policy: keep folder absent until reusable cross-feature modules are introduced (Issue #4)

## Verification
- confirmed no empty directories remain under src/app
- confirmed no dead references to removed folders in routing/imports (features/booking, features/dashboard, features/inventory, src/app/shared)
- npm run build (pass)

Closes #3