### PR TITLE
refactor: move apiBasePath to environment config

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,5 @@
 import { ApplicationConfig, importProvidersFrom, LOCALE_ID, APP_INITIALIZER } from '@angular/core';
+import { environment } from '../environments/environment';
 import { provideRouter } from '@angular/router';
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
@@ -40,7 +41,7 @@ export const appConfig: ApplicationConfig = {
     },
     importProvidersFrom(
       ApiModule.forRoot(() => new Configuration({
-        basePath: '/api/v1', // Configure Base Path for API Client
+        basePath: environment.apiBasePath,
         accessToken: resolveAccessToken
       }))
     )

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'http://localhost:8080'
+  apiUrl: 'http://localhost:8080',
+  apiBasePath: '/api/v1',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: false,
   // apiUrl: 'http://localhost:3000'
-  apiUrl: 'http://localhost:8080'
+  apiUrl: 'http://localhost:8080',
+  apiBasePath: 'http://localhost:8080/api/v1',
 };


### PR DESCRIPTION
## Summary
- Add `apiBasePath` field to both `environment.ts` (dev: `http://localhost:8080/api/v1`) and `environment.prod.ts` (prod: `/api/v1`)
- Replace hardcoded `'/api/v1'` in `app.config.ts` with `environment.apiBasePath`
- No behavior change in production; dev environment now uses absolute URL for local API calls

## Test plan
- [ ] Run `npm run build` — should compile without errors
- [ ] Run local dev server (`npm start`) and confirm API requests reach `http://localhost:8080/api/v1`
- [ ] Verify prod build uses `/api/v1` (relative path) for API calls

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)